### PR TITLE
New .es6.js handlers

### DIFF
--- a/lib/es6/rails/railtie.rb
+++ b/lib/es6/rails/railtie.rb
@@ -7,13 +7,16 @@ module Es6
   module Rails
     class Railtie < ::Rails::Railtie
       config.app_generators.javascript_engine :es6
+      config.app_generators.javascript_engine :"es6.js"
 
       if config.respond_to?(:annotations)
         config.annotations.register_extensions("es6") { |annotation| /#\s*(#{annotation}):?\s*(.*)$/ }
+        config.annotations.register_extensions("es6.js") { |annotation| /#\s*(#{annotation}):?\s*(.*)$/ }
       end
 
       initializer 'override js_template hook' do |app|
-        if app.config.generators.rails[:javascript_engine] == :es6
+        if app.config.generators.rails[:javascript_engine] == :es6 ||
+          app.config.generators.rails[:javascript_engine] == :"es6.js"
           ::Rails::Generators::NamedBase.send :include, Es6::Rails::JsHook
         end
       end

--- a/lib/es6/rails/template_handler.rb
+++ b/lib/es6/rails/template_handler.rb
@@ -15,4 +15,5 @@ end
 
 ActiveSupport.on_load(:action_view) do
   ActionView::Template.register_template_handler :es6, Es6::Rails::TemplateHandler
+  ActionView::Template.register_template_handler :"es6.js", Es6::Rails::TemplateHandler
 end

--- a/lib/es6/rails/version.rb
+++ b/lib/es6/rails/version.rb
@@ -1,5 +1,5 @@
 module Es6
   module Rails
-    VERSION = "0.2.0"
+    VERSION = "0.3.1"
   end
 end


### PR DESCRIPTION
Besides the already supported .es6 format, this PR enables use of .es6.js files as assets and views.